### PR TITLE
Add spm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ use
 var StateMan = require('stateman');
 ```
 
+### [spm](http://spmjs.io/package/stateman)
+
+```js
+spm install stateman
+```
+
+use
+
+```js
+var StateMan = require('stateman');
+```
+
 ### component
 
 ```js

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ StateMan
 
 
 [![Build Status](http://img.shields.io/travis/regularjs/regular/master.svg?style=flat-square)](http://travis-ci.org/regularjs/regular)
+[![spm package](http://spmjs.io/badge/stateman)](http://spmjs.io/package/stateman)
 
 
 stateman: A tiny foundation that providing nested state-based routing for complex web application. 

--- a/package.json
+++ b/package.json
@@ -49,5 +49,14 @@
     "gulp-prompt": "^0.1.1",
     "gulp-tag-version": "^1.0.2",
     "yargs": "^1.3.1"
+  },
+  "spm": {
+    "main": "src/index.js",
+    "ignore": [
+      "docs",
+      "example",
+      "scripts",
+      "test"
+    ]
   }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/stateman

---

It is a browser-side package manager popular in China, suppling a complete lifecycle managment of package via [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of stateman in spmjs, I can add it for your account after signing in http://spmjs.io.

spmjs/spm#781